### PR TITLE
fix: failing installation on ubuntu1604

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,7 @@
   package:
     name: unzip
     state: present
+    update_cache: true
 
 - name: create promtail group
   group:


### PR DESCRIPTION
Due to package lists not being recent in certain szenarios the installation
of the role would fail, as it would not find the upstream `unzip` repository