### PR TITLE
feat: install promtail 1.4.1 by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-promtail_version: "1.3.0"
+promtail_version: "1.4.1"
 promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-amd64.zip"
 promtail_config_dir: /etc/promtail
 promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -58,4 +58,4 @@ def test_grpc_socket(host):
 def test_version(host, AnsibleDefaults):
     version = os.getenv('PROMTAIL', AnsibleDefaults['promtail_version'])
     out = host.run("/usr/local/bin/promtail --version").stdout
-    assert "promtail, version v" + version in out
+    assert "promtail, version " + version in out

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -58,4 +58,5 @@ def test_grpc_socket(host):
 def test_version(host, AnsibleDefaults):
     version = os.getenv('PROMTAIL', AnsibleDefaults['promtail_version'])
     out = host.run("/usr/local/bin/promtail --version").stdout
-    assert "promtail, version " + version in out
+    assert version in out
+    assert "promtail" in out


### PR DESCRIPTION
Promtail 1.4.1 has been released, make it the default version to be installed