### PR TITLE
Feat add file sd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `promtail_version` | "1.3.0" | promtail package version. Also accepts *latest* as parameter. |
+| `promtail_version` | "1.4.1" | promtail package version. Also accepts *latest* as parameter. |
 | `promtail_config_dir` | /etc/promtail | Directory for storing promtail configuration file |
 | `promtail_config_file` | "{{ promtail_config_dir }}/promtail.yml" | Configuration file used by promtail |
 | `promtail_system_user` | promtail | User the promtail process will run at |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `promtail_version` | "1.4.1" | promtail package version. Also accepts *latest* as parameter. |
 | `promtail_config_dir` | /etc/promtail | Directory for storing promtail configuration file |
+| `promtail_config_file_sd_dir` | "{{ promtail_config_dir }}/file_sd" | Default directory for `file_sd` discovery |
 | `promtail_config_file` | "{{ promtail_config_dir }}/promtail.yml" | Configuration file used by promtail |
 | `promtail_system_user` | promtail | User the promtail process will run at |
 | `promtail_system_group` | "{{ promtail_system_user }}" | Group of the *promtail* user |
@@ -34,6 +35,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `promtail_config_scrape_configs` | [] | promtail [scrap_configs](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#scrape_config) section |
 | `promtail_target_config` | {} | promtail [target_config](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#target_config) section |
 | `promtail_log_level` | "info" | Loglevel of promtail (one of: `debug`,`info`,`warn`,`error` ) |
+| `promtail_config_include_default_file_sd_config` | "True" | When set to false, the default `file_sd` will not be provisioned |
 
 For each section (`promtail_config_clients`, `promtail_config_server`,`promtail_config_positions`,`promtail_config_scrape_configs`,`promtail_target_config`) the configuration can be passed accrodingly to the [official promtail configuration](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md). 
 The role will converte the ansible vars into the respective yaml configuration for loki.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 promtail_version: "1.4.1"
 promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-amd64.zip"
 promtail_config_dir: /etc/promtail
+promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"
 promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
 
 promtail_system_user: promtail
@@ -36,6 +37,16 @@ promtail_config_scrape_configs: []
 #          job: varlogs
 #          host: {{ ansible_hostname }}
 #          __path__: /var/log/*log
+
+promtail_config_include_default_file_sd_config: True
+
+promtail_config_default_file_sd_config:
+  - job_name: file_sd
+    file_sd_configs:
+      - files:
+          - "{{ promtail_config_file_sd_dir }}/*.yml"
+          - "{{ promtail_config_file_sd_dir }}/*.yaml"
+          - "{{ promtail_config_file_sd_dir }}/*.json"
 
 promtail_target_config: {}
 #  promtail_target_config:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,7 +16,8 @@ def AnsibleDefaults():
 
 @pytest.mark.parametrize("dir", [
     "/opt/promtail",
-    "/etc/promtail"
+    "/etc/promtail",
+    "/etc/promtail/file_sd",
 ])
 def test_directories(host, dir):
     d = host.file(dir)

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -9,7 +9,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.parametrize("dir", [
     "/opt/promtail",
-    "/etc/promtail"
+    "/etc/promtail",
+    "/etc/promtail/file_sd",
 ])
 def test_directories(host, dir):
     d = host.file(dir)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,7 @@
     mode: 0770
   with_items:
     - "{{ promtail_config_dir }}"
+    - "{{ promtail_config_file_sd_dir }}"
 
 - name: Create application dirs
   file:

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -16,7 +16,9 @@ scrape_configs:
   {% if promtail_config_include_default_file_sd_config | bool %}
   {{ promtail_config_default_file_sd_config | to_nice_yaml(indent=2) | indent(2, False) }}
   {% endif %}
+  {% if promtail_config_scrape_configs|length %}
   {{ promtail_config_scrape_configs | to_nice_yaml(indent=2) | indent(2, False) }}
+  {% endif %}
 
 {% if promtail_target_config != {} %}
 target_config:

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -13,6 +13,9 @@ clients:
   {{ promtail_config_clients | to_nice_yaml(indent=2) | indent(2, False) }}
 
 scrape_configs:
+  {% if promtail_config_include_default_file_sd_config | bool %}
+  {{ promtail_config_default_file_sd_config | to_nice_yaml(indent=2) | indent(2, False) }}
+  {% endif %}
   {{ promtail_config_scrape_configs | to_nice_yaml(indent=2) | indent(2, False) }}
 
 {% if promtail_target_config != {} %}


### PR DESCRIPTION
# Motivation

Have a default `file_sd` configuration directly integrated in the role to ease the integration with services/roles/applications that need custom configurations 