### PR TITLE
fix: raise privileges of restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Restart promtail
+  become: True
   systemd:
     name: promtail
     state: restarted


### PR DESCRIPTION
The restart handler does not escalate privileges.

I'm seeing this failure on Ubuntu 20.04 LTS.

```
RUNNING HANDLER [promtail : Restart promtail] ***********************************************************
fatal: [loki-monolith-s-instance]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to reload daemon: Access denied\n"}
```