### PR TITLE
fix: use sed to correctly extract only the latest changelog entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           VERSION=$(echo "${COMMIT_MSG}" | grep -Po '\d.\d.\d')
-          CHANGELOG=$(cat CHANGELOG.md | grep -Pzo '(?s)##.*?##')
+          CHANGELOG=$(cat CHANGELOG.md | sed -n '/^## \[/{p; :loop n; /^## \[/q; p; b loop}')
           CHANGELOG="${CHANGELOG%??}"
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"


### PR DESCRIPTION
Using grep in pcre mode was a quick and dirty solution, however neading
to deal with multiple matches it became apparent that its easier to
use a simple sed stream to select the first match and then exit