### PR TITLE
Add host/group scrape blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `promtail_loki_server_url` | http://127.0.0.1:3100 | Server url where promtail will push its result |
 | `promtail_config_server` | see [defaults/main.yml](defaults/main.yml) | promtail [server_config](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#server_config) section |
 | `promtail_config_positions` | {} | promtail [position_config](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#position_config) section |
-| `promtail_config_scrape_configs` | [] | promtail [scrap_configs](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#scrape_config) section |
+| `promtail_config_scrape_configs` | [] | promtail [scrape_config](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#scrape_config) section |
+| `promtail_config_scrape_configs_group` | [] | same as promtail_config_scrape_configs for usage at group-level |
+| `promtail_config_scrape_configs_host` | [] | same as promtail_config_scrape_configs for usage at host-level |
 | `promtail_target_config` | {} | promtail [target_config](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md#target_config) section |
 | `promtail_log_level` | "info" | Loglevel of promtail (one of: `debug`,`info`,`warn`,`error` ) |
 | `promtail_config_include_default_file_sd_config` | "True" | When set to false, the default `file_sd` will not be provisioned |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ promtail_config_scrape_configs: []
 #          host: {{ ansible_hostname }}
 #          __path__: /var/log/*log
 
+promtail_config_scrape_configs_group: []
+promtail_config_scrape_configs_host: []
+
 promtail_config_include_default_file_sd_config: True
 
 promtail_config_default_file_sd_config:

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -19,6 +19,12 @@ scrape_configs:
   {% if promtail_config_scrape_configs|length %}
   {{ promtail_config_scrape_configs | to_nice_yaml(indent=2) | indent(2, False) }}
   {% endif %}
+  {% if promtail_config_scrape_configs_group|length %}
+  {{ promtail_config_scrape_configs_group | to_nice_yaml(indent=2) | indent(2, False) }}
+  {% endif %}
+  {% if promtail_config_scrape_configs_host|length %}
+  {{ promtail_config_scrape_configs_host | to_nice_yaml(indent=2) | indent(2, False) }}
+  {% endif %}
 
 {% if promtail_target_config != {} %}
 target_config:


### PR DESCRIPTION
This PR adds two variables, similar to promtail_config_scrape_configs, but for using at host and group level.
Use case scenario:

Use promtail_config_scrape_configs at group all - ie systemd scraping and other generic stuff you can pull from all machines
Use promtail_config_scrape_configs_group in ansible groups (ie db clusters, app logs, etc)
And same for _host should someone have the need.

Does nothing by default. Doesn't break existing installs.