### PR TITLE
feat: add support for arm architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Description
 
-Deploy [promtail](https://github.com/grafana/loki) using ansible.
+Deploy [promtail](https://github.com/grafana/loki) using ansible. Supports amd64 and arm architectures.
 For recent changes, please check the [CHANGELOG](/CHANGELOG.md) or have a look at [github releases](https://github.com/patrickjahns/ansible-role-promtail/releases)
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 promtail_version: "1.5.0"
-promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-amd64.zip"
+promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-{{ go_arch }}.zip"
 promtail_config_dir: /etc/promtail
 promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"
 promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"


### PR DESCRIPTION
# Motivation

I want to be able to deploy promtail on arm based systems (i.e. raspberry pi ) with the same role as I would use for my x86 based systems. 

# Description

Extend `promtail_dist_url` to utilize the already existing `go_arch` variable in order to map cpu architectures to upstream binary names

closes #22 