### PR TITLE
chore(binary): update promtail to version 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `promtail_version` | "1.5.0" | promtail package version. Also accepts *latest* as parameter. |
+| `promtail_version` | "1.6.0" | promtail package version. Also accepts *latest* as parameter. |
 | `promtail_config_dir` | /etc/promtail | Directory for storing promtail configuration file |
 | `promtail_config_file_sd_dir` | "{{ promtail_config_dir }}/file_sd" | Default directory for `file_sd` discovery |
 | `promtail_config_file` | "{{ promtail_config_dir }}/promtail.yml" | Configuration file used by promtail |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-promtail_version: "1.5.0"
+promtail_version: "1.6.0"
 promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-{{ go_arch }}.zip"
 promtail_config_dir: /etc/promtail
 promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"


### PR DESCRIPTION
As loki 1.6.0 is released so is promtail. 
https://github.com/grafana/loki/releases/tag/v1.6.0
