### PR TITLE
CI: fix testing by pinning dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ docker
 ansible-lint>=3.4.0
 pytest-testinfra
 flake8
+rich < 9.5


### PR DESCRIPTION
# Motivation

Currently CI is broken to due an issue with a dependency - see https://github.com/ansible-community/molecule/issues/3010