### PR TITLE
Remove entry parser setting from example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Basic playbook that will assume that loki will be listening at `http://127.0.0.1
       vars: 
         promtail_config_scrape_configs:
           - job_name: system
-            entry_parser: raw
             static_configs:
             - targets:
                 - localhost
@@ -83,7 +82,6 @@ A more complex example, that overrides server, client, positions configuration a
 
         promtail_config_scrape_configs:
           - job_name: system
-            entry_parser: raw
             static_configs:
             - targets:
                 - localhost


### PR DESCRIPTION
Related to issue #47, looks like this isn't needed any more.  Taking this out appears to solve my deployment issues.  