### PR TITLE
ci: ensure the release version is properly parsed in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: extract version from commit message
         shell: bash
         run: |
-          VERSION=$(echo "${COMMIT_MSG}" | grep -Po '\d.\d.\d')
+          VERSION=$(echo "${COMMIT_MSG}" | grep -Po '\d+.\d+.\d+')
           CHANGELOG=$(cat CHANGELOG.md | sed -n '/^## \[/{p; :loop n; /^## \[/q; p; b loop}')
           CHANGELOG="${CHANGELOG%??}"
           CHANGELOG="${CHANGELOG//'%'/'%25'}"


### PR DESCRIPTION
# Motivation

Have a working release pipeline

# Description

Currently the pipeline would only work with single digit versions - this change ensures that also double digit version numbers will work

Solves #53 