### PR TITLE
Add possibility to opt out of APT cache updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `promtail_target_config` | {} | promtail [target_config](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#target_config) section |
 | `promtail_log_level` | "info" | Loglevel of promtail (one of: `debug`,`info`,`warn`,`error` ) |
 | `promtail_config_include_default_file_sd_config` | "True" | When set to false, the default `file_sd` will not be provisioned |
+| `promtail_apt_update_cache` | "True" | When set to false the role will not update the APT cache on its own |
 
 For each section (`promtail_config_clients`, `promtail_config_server`,`promtail_config_positions`,`promtail_config_scrape_configs`,`promtail_target_config`) the configuration can be passed accrodingly to the [official promtail configuration](https://github.com/grafana/loki/blob/master/docs/clients/promtail/configuration.md).
 The role will converte the ansible vars into the respective yaml configuration for loki.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For recent changes, please check the [CHANGELOG](/CHANGELOG.md) or have a look a
 
 ## Requirements
 
-- Ansible >= 2.7 
+- Ansible >= 2.7
 
 ## Role Variables
 
@@ -51,7 +51,7 @@ Basic playbook that will assume that loki will be listening at `http://127.0.0.1
 - hosts: all
   roles:
     - role: patrickjahns.promtail
-      vars: 
+      vars:
         promtail_config_scrape_configs:
           - job_name: system
             static_configs:
@@ -69,7 +69,7 @@ A more complex example, that overrides server, client, positions configuration a
 - hosts: all
   roles:
     - role: patrickjahns.promtail
-      vars: 
+      vars:
         promtail_config_server:
           http_listen_port: 9080
           grpc_listen_port: 9081

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+promtail_apt_update_cache: True
+
 promtail_version: "2.2.1"
 promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-{{ go_arch }}.zip"
 promtail_config_dir: /etc/promtail

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,7 @@
   package:
     name: unzip
     state: present
-    update_cache: True
+    update_cache: "{{ promtail_apt_update_cache }}"
 
 - name: Create promtail group
   group:


### PR DESCRIPTION
With the `promtail_apt_update_cache` option users can now opt out of
cache updates executed by this role.

This is helpful, since if multiple tasks want to update the
package cache in the same play it will be unecessarily prolonged.

Closes #63 

This should work, but I haven't tested it.