### PR TITLE
chore: bump promtail to 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `promtail_version` | "2.3.0" | promtail package version. Also accepts *latest* as parameter. |
+| `promtail_version` | "2.4.1" | promtail package version. Also accepts *latest* as parameter. |
 | `promtail_config_dir` | /etc/promtail | Directory for storing promtail configuration file |
 | `promtail_config_file_sd_dir` | "{{ promtail_config_dir }}/file_sd" | Default directory for `file_sd` discovery |
 | `promtail_config_file` | "{{ promtail_config_dir }}/promtail.yml" | Configuration file used by promtail |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 promtail_apt_update_cache: True
-promtail_version: "2.3.0"
+promtail_version: "2.4.1"
 promtail_dist_url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-{{ go_arch }}.zip"
 promtail_config_dir: /etc/promtail
 promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -58,9 +58,7 @@ def test_grpc_socket(host):
 
 
 def test_version(host, AnsibleDefaults):
-    # version = os.getenv('PROMTAIL', AnsibleDefaults['promtail_version'])
+    version = os.getenv('PROMTAIL', AnsibleDefaults['promtail_version'])
     out = host.run("/usr/local/bin/promtail --version").stdout
-    # With loki 2.3 the version output is broken - so we skip this for now
-    # https://github.com/grafana/loki/issues/4115
-    # assert version in out
+    assert version in out
     assert "promtail" in out


### PR DESCRIPTION
# Motivation

Have recent version of grafana promtail running - https://github.com/grafana/loki/releases/tag/v2.4.1