### PR TITLE
Update meta and CI to show Debian Bullseye support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
           - ANSIBLE: "4.3"
             MOLECULE_DISTRO: debian10
           - ANSIBLE: "4.3"
+            MOLECULE_DISTRO: debian11
+          - ANSIBLE: "4.3"
             MOLECULE_DISTRO: centos7
           - ANSIBLE: "4.3"
             MOLECULE_DISTRO: centos8

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,7 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        - bullseye
   galaxy_tags:
     - promtail
     - loki


### PR DESCRIPTION
This role has been tested and works against Debian Bullseye.  Let others know and include in future CI tests.