### PR TITLE
Add promtail_systemd_service variable (needed to configure multiple promtail instances).

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"
 promtail_user_additional_groups: "adm"
+promtail_systemd_service: promtail
 
 promtail_install_dir: /opt/promtail
 promtail_tmp_dir: /tmp

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: Restart promtail
   become: True
   systemd:
-    name: promtail
+    name: "{{ promtail_system_service }}"
     state: restarted
     daemon_reload: True
   tags:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: Restart promtail
   become: True
   systemd:
-    name: "{{ promtail_system_service }}"
+    name: "{{ promtail_systemd_service }}"
     state: restarted
     daemon_reload: True
   tags:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -100,5 +100,5 @@
     - Restart promtail
   template:
     src: service.j2
-    dest: /etc/systemd/system/promtail.service
+    dest: "/etc/systemd/system/{{ promtail_systemd_service }}.service"
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   become: True
   systemd:
     daemon_reload: True
-    name: promtail
+    name: "{{ promtail_systemd_service }}"
     state: started
     enabled: True
   tags:


### PR DESCRIPTION
Introduce promtail_systemd_service variable (defaults to promtail). Replace hardcoded references to promtail systemd service with {{ promtail_systemd_service }}.
Needed to configure multiple promtail instances.