### PR TITLE
Remove deprecated `include`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- include: preflight.yml
+- import_tasks: preflight.yml
   tags:
     - promtail_install
     - promtail
 
-- include: install.yml
+- import_tasks: install.yml
   become: True
   tags:
     - promtail_install


### PR DESCRIPTION
Replaces the use of the deprecated keyword `include` and replaces it with the static `import_tasks`