### PR TITLE
Don't use run_once for getting checksums

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -29,7 +29,6 @@
 - name: "Get checksum list"
   set_fact:
     __promtail_checksums: "{{ lookup('url', 'https://github.com/grafana/loki/releases/download/v' + promtail_version + '/SHA256SUMS', wantlist=True) | list }}"
-  run_once: True
 
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html#running-on-a-single-machine-with-run-once says that `run_once` gets executed only on the first host in batch.
This makes getting checksums fail for the whole run if that host skips this role for whatever reason.

Fixes https://github.com/patrickjahns/ansible-role-promtail/issues/112