### PR TITLE
Add variable promtail_systemd_service_template_file for systemd service template file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"
 promtail_user_additional_groups: "adm"
-promtail_systemd_service_file_path: service.j2
+promtail_systemd_service_template_path: service.j2
 promtail_systemd_service: promtail
 
 promtail_install_dir: /opt/promtail

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"
 promtail_user_additional_groups: "adm"
+promtail_systemd_service_file_path: service.j2
 promtail_systemd_service: promtail
 
 promtail_install_dir: /opt/promtail

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"
 promtail_user_additional_groups: "adm"
-promtail_systemd_service_template_path: service.j2
+promtail_systemd_service_template_file: service.j2
 promtail_systemd_service: promtail
 
 promtail_install_dir: /opt/promtail

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -99,6 +99,6 @@
   notify:
     - Restart promtail
   template:
-    src: "{{ promtail_systemd_service_template_path }}"
+    src: "{{ promtail_systemd_service_template_file }}"
     dest: "/etc/systemd/system/{{ promtail_systemd_service }}.service"
     mode: 0644

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -99,6 +99,6 @@
   notify:
     - Restart promtail
   template:
-    src: service.j2
+    src: "{{ promtail_systemd_service_file_path }}"
     dest: "/etc/systemd/system/{{ promtail_systemd_service }}.service"
     mode: 0644

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -99,6 +99,6 @@
   notify:
     - Restart promtail
   template:
-    src: "{{ promtail_systemd_service_file_path }}"
+    src: "{{ promtail_systemd_service_template_path }}"
     dest: "/etc/systemd/system/{{ promtail_systemd_service }}.service"
     mode: 0644


### PR DESCRIPTION
### Changes
- Adds variable `promtail_systemd_service_template_path` for systemd service template file path

### Use Case
Enables the use of a custom systemd service configuration file by providing the path to the custom template.
In our case, we need to add some additional settings in the service file to increase the limit of open files for some hosts that have too many log files.