### PR TITLE
parametrize promtail config template file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ promtail_custom_checksum: ""
 promtail_config_dir: /etc/promtail
 promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"
 promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
+promtail_config_template_file: config.j2
 
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -89,7 +89,7 @@
   notify:
     - Restart promtail
   template:
-    src: config.j2
+    src: "{{ promtail_config_template_file }}"
     dest: "{{ promtail_config_file }}"
     owner: root
     group: "{{ promtail_system_group }}"


### PR DESCRIPTION
We'd like to have the option to pass custom `config.j2` to the role.
The role already allows the same for the `service.j2`.