### PR TITLE
Set promtail user home to install directory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     shell: /usr/sbin/nologin
     system: True
     createhome: False
-    home: /
+    home: "{{ promtail_install_dir }}"
   when: promtail_system_user != "root"
 
 - name: Ensure /usr/local/bin exists


### PR DESCRIPTION
This PR sets the home directory of the promtail user to the `promtail_install_dir` (`/opt/promtail`).

When reverting the installation with ansible a `/` as home could lead to the deletion of the whole system when using [ansible.builtin.user module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html) with:
```yaml
# revert promtail installation …
- name: "Remove promtail"
  # …

  vars:
    # …
    promtail_system_user: promtail

  tasks:
    # … 
    - name: "Remove promtail user"
      ansible.builtin.user:
        name: "{{ promtail_system_user }}"
        state: absent
        remove: true  # defaults: false
        force: true   # defaults: false
    # …
```

This may be a edge case, since ansible defaults are safe. But setting the home to a safer location prevents from deleting the whole root.