### PR TITLE
Remove home parameter in user task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,6 @@
     shell: /usr/sbin/nologin
     system: True
     createhome: False
-    home: "{{ promtail_install_dir }}"
   when: promtail_system_user != "root"
 
 - name: Ensure /usr/local/bin exists


### PR DESCRIPTION
Fixes #140 

Fixes regression introduced in 835faa8. Changing the users home on existing installations will result in failing the user task with:

```
usermod: user promtail is currently used by process…
```

Since promtail is already running on an existing installation the promtail users home can't be changed without stopping the processes of the user.

Omitting the home attribute will not touch the home of existing promtail users. On new installations it will be set to
`/home/{{ promtail_system_user }}` (`/home/promtail`), which won't be created b/c `createhome: False` is set.