### PR TITLE
fix: fail early when using promtail_binary_local_dir

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -26,12 +26,21 @@
   when:
     - promtail_version == "latest"
 
-- name: Test if zip local archive exists
-  stat:
-    path: "{{ promtail_binary_local_dir }}/{{ promtail_version }}_promtail-linux-{{ go_arch }}.zip"
-  register: promtail_binary_local_archive
-  delegate_to: localhost
-  run_once: True
+- block:
+  - name: Test if zip local archive exists
+    stat:
+      path: "{{ promtail_binary_local_dir }}/{{ promtail_version }}_promtail-linux-{{ go_arch }}.zip"
+    register: promtail_binary_local_archive
+    delegate_to: localhost
+    run_once: True
+
+  - name: Assert local binary exists
+    assert:
+      that: promtail_binary_local_archive.stat.exists
+      msg: "When using 'promtail_binary_local_dir' please ensure that the binary exists"
+
+  when:
+    - promtail_binary_local_dir | length > 0
 
 - block:
     - name: "Get checksum list"
@@ -47,4 +56,3 @@
         - "('promtail-linux-' + go_arch + '.zip') in item"
   when:
     - promtail_binary_local_dir | length == 0
-    - not promtail_binary_local_archive.stat.exists


### PR DESCRIPTION
# Motivation

Fail early in the `preflight` part of the role when using `promtail_binary_local_dir` and the binary does not exist.
This prevents performing already changes on the system when we can not reach a desired state without issues