### PR TITLE
fix(preflight): do not become root when delegating tasks to localhost

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -31,6 +31,7 @@
     stat:
       path: "{{ promtail_binary_local_dir }}/{{ promtail_version }}_promtail-linux-{{ go_arch }}.zip"
     register: promtail_binary_local_archive
+    become: false
     delegate_to: localhost
     run_once: True
 


### PR DESCRIPTION
# Description

When using the module with `become: true` tasks that are running on localhost will fail since some locahost computers require passwords. This will make sure to run localhost tasks as the current user that is running ansible locally.

Fixes #155 