### PR TITLE
Revert back to fetching of version information from localhost

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -25,6 +25,8 @@
         promtail_version: "{{ _latest_release.json.tag_name[1:] }}"
   when:
     - promtail_version == "latest"
+  delegate_to: localhost
+  run_once: True
 
 - block:
   - name: Test if zip local archive exists


### PR DESCRIPTION
This was introduced in 0c331ed, but later (by mistake?) dropped in aa512cd and as a result this playbook will again hit GitHub rate limits with larger number of hosts.