### PR TITLE
fix: changed set_fact to uri call

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -46,15 +46,21 @@
 
 - block:
     - name: "Get checksum list"
-      set_fact:
-        __promtail_checksums: "{{ lookup('url', 'https://github.com/grafana/loki/releases/download/v' + promtail_version + '/SHA256SUMS', wantlist=True) | list }}"
-      run_once: True
+      uri:
+        url: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/SHA256SUMS"
+        method: GET
+        return_content: True
+        status_code: 200
+        body_format: json
+        validate_certs: False
+      register: __promtail_checksums
 
     - name: "Get checksum for {{ go_arch }} architecture"
       set_fact:
         __promtail_checksum: "{{ item.split(' ')[0] }}"
-      with_items: "{{ __promtail_checksums }}"
+      with_items: "{{ __promtail_checksums.content | split('\n') }}"
       when:
         - "('promtail-linux-' + go_arch + '.zip') in item"
+
   when:
     - promtail_binary_local_dir | length == 0


### PR DESCRIPTION
Notes: 
   The set_fact was causing the following error:
```
objc[18913]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
```
this change corrects this whilst keeping the desired functionality.