### PR TITLE
Updated `config.expand-env` related variable and templating

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ promtail_custom_checksum: ""
 promtail_config_dir: /etc/promtail
 promtail_config_file_sd_dir: "{{ promtail_config_dir }}/file_sd"
 promtail_config_file: "{{ promtail_config_dir }}/promtail.yml"
-promtail_config_expand_env: "false"
+promtail_config_expand_env: False
 
 promtail_system_user: promtail
 promtail_system_group: "{{ promtail_system_user }}"

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -11,7 +11,7 @@ RestartSec=5
 TimeoutSec=5
 User={{ promtail_system_user }}
 Group={{ promtail_system_group }}
-ExecStart=/usr/local/bin/promtail -config.file={{ promtail_config_file }} -log.level={{ promtail_log_level }} -config.expand-env={{ "true" if promtail_config_expand_env else "false" }}
+ExecStart=/usr/local/bin/promtail -config.file={{ promtail_config_file }} -log.level={{ promtail_log_level }} -config.expand-env={{ promtail_config_expand_env | lower }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Resolved #187.

`promtail_config_expand_env` variable changed from `"false"` to `False` to avoid templating issue.

`-config.expand-env={{ "true" if promtail_config_expand_env else "false" }}` templating has been simplified, now it's `-config.expand-env={{ promtail_config_expand_env | lower }}`