### PR TITLE
fix: disable long lines splitting in promtail_config_scrape_configs

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -17,7 +17,7 @@ scrape_configs:
   {{ promtail_config_default_file_sd_config | to_nice_yaml(indent=2) | indent(2, False) }}
   {% endif %}
   {% if promtail_config_scrape_configs|length %}
-  {{ promtail_config_scrape_configs | to_nice_yaml(indent=2) | indent(2, False) }}
+  {{ promtail_config_scrape_configs | to_nice_yaml(indent=2, width=2147483647) | indent(2, False) }}
   {% endif %}
 
 {% if promtail_target_config != {} %}


### PR DESCRIPTION
In some cases to_nice_yaml splitting long lines (>80 symbols) incorrectly.

<details><summary>Example</summary>
<p>

This block in `promtail_config_scrape_configs` :

```yaml
  - job_name: nginx-access
    static_configs:
    - targets:
        - localhost
      labels:
        job: nginx-access
        __path__: <path>
    pipeline_stages:
      - json:
          expressions:
            time_local: time
            remote_addr: remote_addr
            method: method
            path: path
            query: request_query
            status: status
            bytes_sent: bytes_sent
            body_bytes_sent: body_bytes_sent
            upstream_time: upstream_time
            request_time: request_time
            host: host
            protocol: request_proto
            http_user_agent: http_user_agent
          drop_malformed: true
      - labels:
          host:
          path:
          status:
          method:
      - template:
          source: out_msg
          template: '{% raw %}{{ .remote_addr }} {{ .protocol }} {{ .method }} {{ .host }}{{ .path }}{{ if ne .query "-" }}?{{ .query }}{{ end }} {{ .status }} {{ .body_bytes_sent }} {{ .upstream_time }} {{ .request_time }} {{ .http_user_agent }}{% endraw %}'
      - timestamp:
          source: time_local
          format: RFC3339
      - output:
          source: out_msg
```

Will be rendered as:

```yaml
  - job_name: nginx-access
    pipeline_stages:
    - json:
        drop_malformed: true
        expressions:
          body_bytes_sent: body_bytes_sent
          bytes_sent: bytes_sent
          host: host
          http_user_agent: http_user_agent
          method: method
          path: path
          protocol: request_proto
          query: request_query
          remote_addr: remote_addr
          request_time: request_time
          status: status
          time_local: time
          upstream_time: upstream_time
    - labels:
        host: null
        method: null
        path: null
        status: null
    - template:
        source: out_msg
        template: '{{ .remote_addr }} {{ .protocol }} {{ .method }} {{ .host }}{{ .path
          }}{{ if ne .query "-" }}?{{ .query }}{{ end }} {{ .status }} {{ .body_bytes_sent
          }} {{ .upstream_time }} {{ .request_time }} {{ .http_user_agent }}'
    - timestamp:
        format: RFC3339
        source: time_local
    - output:
        source: out_msg
    static_configs:
    - labels:
        __path__: <path>
        job: nginx-access
      targets:
      - localhost
```

With splitting `template` in multiple, which is not valid promtail config
</p>
</details> 

To fix this I have added `width` parameter for promtail_config_scrape_configs in config template to disable line splitting.

Closes https://github.com/patrickjahns/ansible-role-promtail/issues/196