### PR TITLE
ci: bumped ansible test versions and base os versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,33 +32,37 @@ jobs:
             MOLECULE_SCENARIO: default
           - ANSIBLE: "5.10"
             MOLECULE_SCENARIO: default
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "6.7"
+            MOLECULE_SCENARIO: default
+          - ANSIBLE: "7.7"
+            MOLECULE_SCENARIO: default
+          - ANSIBLE: "8.7"
+            MOLECULE_SCENARIO: default
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: latest
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: upgrade
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: scenario_with_local_binary_directory
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: download_and_propagate
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: default
             MOLECULE_DISTRO: ubuntu2004
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: default
             MOLECULE_DISTRO: ubuntu2204
-          - ANSIBLE: "6.6"
-            MOLECULE_SCENARIO: default
-            MOLECULE_DISTRO: debian10
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
             MOLECULE_SCENARIO: default
             MOLECULE_DISTRO: debian11
-#          - ANSIBLE: "4.3"
-#            MOLECULE_DISTRO: centos7
-          - ANSIBLE: "6.6"
+          - ANSIBLE: "9.4"
+            MOLECULE_SCENARIO: default
+            MOLECULE_DISTRO: debian12
+          - ANSIBLE: "9.4"
             MOLECULE_DISTRO: centos8
             MOLECULE_SCENARIO: default
-          - ANSIBLE: "6.6"
-            MOLECULE_DISTRO: fedora37
+          - ANSIBLE: "9.4"
+            MOLECULE_DISTRO: fedora39
             MOLECULE_SCENARIO: default
     steps:
       - uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,10 @@ ANSIBLE=
   3.4: ansible34
   4.10: ansible410
   5.10: ansible510
-  6.6: ansible66
+  6.7: ansible67
+  7.7: ansible77
+  8.7: ansible87
+  9.4: ansible94
 
 [testenv]
 passenv = GH_*, DOCKER_HOST, MOLECULE_*, OBJC_DISABLE_INITIALIZE_FORK_SAFETY
@@ -33,6 +36,9 @@ deps =
     ansible34: ansible-compat<3
     ansible410: ansible<4.11
     ansible510: ansible<5.11
-    ansible66: ansible<6.7
+    ansible67: ansible<6.8
+    ansible77: ansible<7.8
+    ansible87: ansible<8.8
+    ansible94: ansible<9.5
 commands =
     {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
Improved test matrix to ensure latest ansible-version and more current OS distributions are used for testing