### PR TITLE
Create variable promtail_systemd_service_environment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ promtail_system_group: "{{ promtail_system_user }}"
 promtail_user_additional_groups: "adm"
 promtail_systemd_service_template_file: service.j2
 promtail_systemd_service: promtail
+promtail_systemd_service_environment: ""
 
 promtail_extra_args: []
 

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -11,6 +11,7 @@ RestartSec=5
 TimeoutSec=5
 User={{ promtail_system_user }}
 Group={{ promtail_system_group }}
+Environment={{ promtail_systemd_service_environment }}
 ExecStart=/usr/local/bin/promtail -config.file={{ promtail_config_file }} -log.level={{ promtail_log_level }} -config.expand-env={{ promtail_config_expand_env | lower }} {{ promtail_extra_args | join(' ') }}
 
 [Install]


### PR DESCRIPTION
Add promtail_systemd_service_environment to allow the Environment= line in a systemd service file to be used. For example,

`Environment=HOSTNAME=%H`

is needed to make the HOSTNAME environment variable of systemd available to the promtail configuration file for expansion.

Default value is blank and will not harm anyone who chooses not to use it.