### PR TITLE
fix: decrypt vault-encrypted values in client config before YAML serialization

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -10,7 +10,7 @@ positions:
 {% endif %}
 
 clients:
-  {{ promtail_config_clients | to_nice_yaml(indent=2) | indent(2, False) }}
+  {{ promtail_config_clients | to_json | from_json | to_nice_yaml(indent=2) | indent(2, False) }}
 
 scrape_configs:
   {% if promtail_config_include_default_file_sd_config | bool %}


### PR DESCRIPTION
## Summary

- `to_nice_yaml` does not trigger decryption of `AnsibleVaultEncryptedUnicode` objects, causing raw vault ciphertext to be written to the promtail config file when `promtail_config_clients` contains vault-encrypted passwords
- Round-tripping through `to_json` (which decrypts vault values by default) and `from_json` ensures all values are plain strings before YAML serialization

Related Ansible issues:
- https://github.com/ansible/ansible/issues/84380
- https://github.com/ansible/ansible/issues/85722
- https://github.com/ansible/ansible/issues/83359